### PR TITLE
영혼을 갈아 넣은 todo

### DIFF
--- a/css/inedx.css
+++ b/css/inedx.css
@@ -332,4 +332,5 @@ main {
 .info a:hover {
     text-decoration: underline;
 }
-Footer
+
+Footer {}

--- a/index.html
+++ b/index.html
@@ -7,17 +7,14 @@
     <link rel="stylesheet" href="./css/inedx.css" />
   </head>
   <body>
-    <div class="todoapp">
+    <div class="js-todo-app">
       <h1>TODOS</h1>
-      <input
-        id="new-todo-title"
-        class="new-todo"
-        placeholder="할일을 추가해주세요"
-        autofocus
-      />
       <main>
+        <section class="js-new-todo"></section>
+        <section class="js-todo-list"></section>
+
         <input class="toggle-all" type="checkbox" />
-        <ul id="todo-list" class="todo-list"></ul>
+        
         <div class="count-container">
           <span class="todo-count">총 <strong>0</strong> 개</span>
           <ul class="filters">
@@ -34,5 +31,6 @@
         </div>
       </main>
     </div>
+    <script type="module" src="./js/index.js"></script>
   </body>
 </html>

--- a/js/Controllers/NewTodoFormController.js
+++ b/js/Controllers/NewTodoFormController.js
@@ -1,0 +1,18 @@
+import { NewTodoFormEventType } from '../CustomEvents/NewTodoFormEvent.js'
+
+class NewTodoFormController {
+  constructor(views, models) {
+    this.views = views
+    this.models= models
+  }
+
+  initialize() {
+    this.views.newTodoForm.on(NewTodoFormEventType.Submit, this.handleSubmitNewTodo.bind(this))
+  }
+
+  handleSubmitNewTodo({ detail: { todoTitle } }) {
+    this.models.todoList.add(todoTitle)
+  }
+} 
+
+export default NewTodoFormController

--- a/js/Controllers/TodoListController.js
+++ b/js/Controllers/TodoListController.js
@@ -1,0 +1,34 @@
+import { TodoListEventType } from "../Models/TodoList.js"
+import { TodoListViewEventType } from "../Views/TodoListView.js"
+
+class TodoListController {
+  constructor (views, models) {
+    this.views = views
+    this.models = models
+  }
+
+  initialize () {
+    this.models.todoList.on(TodoListEventType.todoListChanged, this.handleTodoListChanged.bind(this))
+    this.views.todoList.on(TodoListViewEventType.checkItem, this.handleCheckTodoListItem.bind(this))
+    this.views.todoList.on(TodoListEventType.destroyItem, this.handleDestroyItem.bind(this))
+    this.views.todoList.on(TodoListViewEventType.editItemTitle, this.handleEditItemTitle.bind(this))
+  }
+
+  handleTodoListChanged({ detail: { todoList }}) {
+    this.views.todoList.updateList(todoList)
+  }
+
+  handleCheckTodoListItem({ detail: { id, completed }}) {
+    this.models.todoList.update(id, { completed })
+  }
+
+  handleDestroyItem({ detail: { id }}) {
+    this.models.todoList.destroy(id)
+  }
+
+  handleEditItemTitle( { detail: { id, itemTitle }}) {
+    this.models.todoList.update(id, { title: itemTitle })
+  }
+}
+
+export default TodoListController

--- a/js/CustomEvents/NewTodoFormEvent.js
+++ b/js/CustomEvents/NewTodoFormEvent.js
@@ -1,0 +1,3 @@
+export const NewTodoFormEventType = {
+  Submit: 'NewTodoFormEventType/Submit',
+}

--- a/js/Models/TodoList.js
+++ b/js/Models/TodoList.js
@@ -1,0 +1,49 @@
+/*
+ * TodoList
+ *   item 
+ *     id
+ *     title
+ *     completed 
+ */
+
+import Model from "./common/Model.js"
+import { getId } from '../Utils/index.js'
+
+export const TodoListEventType = {
+  todoListChanged: 'todoListChanged'
+}
+
+class TodoList extends Model {
+  constructor() {
+    super()
+    this.items = {}
+  }
+
+  add(todoTitle) {
+    const newId = getId()
+    this.items = {
+      ...this.items,
+      [newId]: {
+        id: newId,
+        title: todoTitle,
+        completed: false,
+      }
+    }
+    this.emit(TodoListEventType.todoListChanged, { todoList: Object.values(this.items) })
+  }
+
+  update(id, item) {
+    this.items[id] = {
+      ...this.items[id],
+      ...item,
+    }
+    this.emit(TodoListEventType.todoListChanged, { todoList: Object.values(this.items) })
+  }
+
+  destroy(id) {
+    delete this.items[id]
+    this.emit(TodoListEventType.todoListChanged, { todoList: Object.values(this.items) })
+  }
+}
+
+export default TodoList

--- a/js/Models/common/Model.js
+++ b/js/Models/common/Model.js
@@ -1,0 +1,11 @@
+class Model extends EventTarget {
+  on(eventName, callback) {
+    this.addEventListener(eventName, callback)
+  }
+
+  emit(eventName, payload) {
+    this.dispatchEvent(new CustomEvent(eventName, { detail: payload }))
+  }
+}
+
+export default Model 

--- a/js/Utils/index.js
+++ b/js/Utils/index.js
@@ -1,0 +1,4 @@
+export const getId = (() => {
+  let id = 0
+  return () => id++
+})()

--- a/js/Views/NewTodoFormView.js
+++ b/js/Views/NewTodoFormView.js
@@ -1,0 +1,39 @@
+import View from './common/View.js'
+import { NewTodoFormEventType } from '../CustomEvents/NewTodoFormEvent.js'
+
+class NewTodoFormView extends View {
+  initialize() {
+    this.renderForm()
+    this.bindEventHandlers()
+  }
+
+  renderForm() {
+    this.insertDomStringIntoTargetBeforeEnd(`
+      <form class="js-new-todo-form">
+        <input
+          id="new-todo-title"
+          class="new-todo"
+          name="title"
+          placeholder="할일을 추가해주세요"
+          autofocus
+        />
+      </form>
+    `)
+  }
+
+  bindEventHandlers() {
+    this.$target.querySelector('.js-new-todo-form').addEventListener('submit', this.handleSubmit.bind(this))
+  }
+
+  resetForm() {
+    this.$target.querySelector('.js-new-todo-form').reset()
+  }
+
+  handleSubmit(event) {
+    event.preventDefault()
+    this.emit(NewTodoFormEventType.Submit, { todoTitle: event.target.title.value })
+    this.resetForm()
+  }
+}
+
+export default NewTodoFormView

--- a/js/Views/TodoListView.js
+++ b/js/Views/TodoListView.js
@@ -1,0 +1,95 @@
+import View from './common/View.js'
+
+export const TodoListViewEventType = {
+  checkItem: 'checkItem',
+  destroyItem: 'destroyItem',
+  editItemTitle: 'editItemTitle',
+}
+
+const todoItemTemplate = (item) => `
+  <li ${item.completed ? 'class="completed"' : ''}>
+    <div class="view">
+      <input 
+        type="checkbox" 
+        class="checkbox js-todo-checkbox" 
+        data-id="${item.id}" 
+        ${item.completed ? 'checked' : ''} 
+      /> 
+      <label class="js-todo-title">${item.title}</label>
+      <button class="destroy js-destroy" data-id="${item.id}" />
+    </div>
+    <input class="edit js-editor" value="새로운 타이틀" data-id=${item.id} />
+  </li>
+`
+
+class TodoListView extends View {
+  constructor($target) {
+    super($target)
+  }
+
+  initialize() {
+    this.renderList([])
+    this.bindEventHandlers()
+  }
+
+  renderList(todoItems) {
+    this.insertDomStringIntoTargetBeforeEnd(`
+      <ul id="todo-list" class="todo-list js-todo-list-ul">
+        ${todoItems.map(todoItemTemplate).join('')}
+      </ul>
+    `)
+  }
+
+  updateList(todoItems) {
+    const $ul = this.$target.querySelector('.js-todo-list-ul')
+    $ul.innerHTML = ''
+    $ul.insertAdjacentHTML(
+      'beforeend', 
+      todoItems.map(todoItemTemplate).join(''),
+    )
+  }
+
+  bindEventHandlers() {
+    this.$target.addEventListener('click', this.handleCheckItem.bind(this))
+    this.$target.addEventListener('click', this.handleDeleteItem.bind(this))
+    this.$target.addEventListener('dblclick', this.handleTurnOnEditMode.bind(this))
+    this.$target.addEventListener('keydown', this.handleKeydownOnEditory.bind(this))
+  }
+
+  handleCheckItem(event) {
+    if (event.target.classList.contains('js-todo-checkbox')) {
+      this.emit(TodoListViewEventType.checkItem, { 
+        id: event.target.dataset.id ,
+        completed: event.target.checked,
+      })
+    }
+  }
+
+  handleDeleteItem(event) {
+    if (event.target.classList.contains('js-destroy')) {
+      this.emit(TodoListViewEventType.deleteItem, { id: event.target.dataset.id })
+    }
+  }
+
+  handleTurnOnEditMode(event) {
+    if (!event.target.classList.contains('js-todo-title')) { return }
+
+    const $li = event.target.closest('li')
+    $li.classList.add('editing')
+  }
+
+  handleKeydownOnEditory(event) {
+    if (!event.target.classList.contains('js-editor')) { return}
+
+    if (event.key == 'Enter') { 
+      this.emit(TodoListViewEventType.editItemTitle, { id: event.target.dataset.id, itemTitle: event.target.value })
+    }
+
+    if (event.key === 'Escape') {
+      const $li = event.target.closest('li')
+      $li.classList.remove('editing')
+    }
+  }
+}
+
+export default TodoListView

--- a/js/Views/common/View.js
+++ b/js/Views/common/View.js
@@ -1,0 +1,25 @@
+class View extends EventTarget {
+  constructor($target) {
+    super()
+    this.$target = $target
+  }
+
+  on(eventName, callback) {
+    this.addEventListener(eventName, callback)
+  }
+
+  emit(eventName, payload) {
+    this.dispatchEvent(new CustomEvent(eventName, { detail: payload }))
+  }
+
+  insertDomStringIntoTargetBeforeEnd(domStirng) {
+    this.$target.insertAdjacentHTML('beforeend', domStirng)
+  }
+
+  updateTarget(domString) {
+    this.$target.innerHTML = ''
+    this.insertDomStringIntoTargetBeforeEnd(domString)
+  }
+}
+
+export default View

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,24 @@
+import TodoList from "./Models/TodoList.js"
+import NewTodoFormView from "./Views/NewTodoFormView.js"
+import TodoListView from "./Views/TodoListView.js"
+import NewTodoFormController from "./Controllers/NewTodoFormController.js"
+import TodoListController from "./Controllers/TodoListController.js"
+
+const app = () => {
+  const models = {
+    todoList: new TodoList()
+  }
+  const views = {
+    newTodoForm: new NewTodoFormView(document.querySelector('.js-new-todo')),
+    todoList: new TodoListView(document.querySelector('.js-todo-list'))
+  }
+  const controllers = {
+    newTodoForm: new NewTodoFormController(views, models),
+    todoList: new TodoListController(views, models)
+  }
+
+  Object.values(views).forEach(view => view.initialize())
+  Object.values(controllers).forEach(controller => controller.initialize())
+}
+
+app()


### PR DESCRIPTION
[데모](https://tanney-102.github.io/js-todo-mvc/)

- [x] todo list에 todoItem을 키보드로 입력하여 추가하기
- [x] todo list의 체크박스를 클릭하여 complete 상태로 변경 (li tag 에 completed class 추가, input 태그에 checked 속성 추가)
- [x] todo list의 x버튼을 이용해서 해당 엘리먼트를 삭제
- [x] todo list를 더블클릭했을 때 input 모드로 변경 (li tag 에 editing class 추가) 단 이때 수정을 완료하지 않은 상태에서 esc키를 누르면 수정되지 않은 채로 다시 view 모드로 복귀
- [ ] todo list의 item갯수를 count한 갯수를 리스트의 하단에 보여주기
- [ ] todo list의 상태값을 확인하여, 해야할 일과, 완료한 일을 클릭하면 해당 상태의 아이템만 보여주기